### PR TITLE
fix: 🐛 validate when no recipient address exists

### DIFF
--- a/src/controllers/transaction/transactionFormState.ts
+++ b/src/controllers/transaction/transactionFormState.ts
@@ -182,21 +182,8 @@ export class TransactionFormState extends EventEmitter {
     let shouldUpdateToTokenList = false
 
     if (addressState) {
-      // If fieldValue is empty or invalid address the toChainId should be the same as fromChainId, otherwise
-      // and old state could be stored and transactionType could be wrong
-      if (
-        !addressState.interopAddress &&
-        (!addressState.fieldValue || !isValidAddress(addressState.fieldValue))
-      ) {
-        this.toChainId = this.fromChainId
-      }
-
-      // If ensAddress is NOT empty or fieldValue is a valid address,
-      // toChainId should be the same as fromChainId
-      if (
-        !addressState.interopAddress &&
-        (addressState.ensAddress || isValidAddress(addressState.fieldValue))
-      ) {
+      // If there is no address, or is invalid interop address, toChainId should be the same as fromChainId
+      if (!this.addressState.interopAddress || !this.addressState.fieldValue) {
         this.toChainId = this.fromChainId
       }
 
@@ -574,7 +561,7 @@ export class TransactionFormState extends EventEmitter {
     this.resetForm()
     this.fromChainId = 11155111
     this.fromSelectedToken = null
-    this.toChainId = 111155111
+    this.toChainId = 11155111
     this.portfolioTokenList = []
     this.#toTokenList = []
     this.errors = []

--- a/src/controllers/transaction/transactionManager.ts
+++ b/src/controllers/transaction/transactionManager.ts
@@ -57,6 +57,11 @@ export class TransactionManagerController extends EventEmitter {
    * Error: Same address, same chain, same token -> type: error
    */
   private async handleFormUpdate() {
+    if (!this.formState.recipientAddress || !this.formState.addressState.interopAddress) {
+      this.transactionType = 'error'
+      return
+    }
+
     if (this.formState.fromChainId === this.formState.toChainId) {
       if (this.formState.toSelectedToken?.address === this.formState.fromSelectedToken?.address) {
         if (


### PR DESCRIPTION
## Describe your changes
- validate when no recipient address exists

## Issue ticket number and link

closes https://linear.app/defi-wonderland/issue/EFI-330/show-fee-and-recipient-section-for-a-sec-when-the-user-change-the